### PR TITLE
Add Attach ZIP to GitHub Release Workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Export-ignore files in the root directory that start with a dot
+/.* export-ignore
+
+# Export-ignore a directory named "test" in the root directory
+/test export-ignore
+
+# Export-ignore a file named "phpunit.xml" in the root directory
+/phpunit.xml export-ignore
+
+# Export-ignore a file named "README.md" in the root directory
+/README.md export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Attach ZIP to GitHub Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  attach-zip:
+    name: Attach ZIP to release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.3'
+          tools: composer:v2
+          coverage: none
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Create and attach ZIP
+        uses: concrete5-community/gh-package-release-attach@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          remove-files: |
+            composer.json
+            composer.lock
+          keep-files: |
+            README.md


### PR DESCRIPTION
Let's get rid of exporting zip files manually